### PR TITLE
Fix for calling react_component without props

### DIFF
--- a/Twig/ReactRenderExtension.php
+++ b/Twig/ReactRenderExtension.php
@@ -51,7 +51,7 @@ class ReactRenderExtension extends \Twig_Extension
     public function reactRenderComponent($componentName, $options = array())
     {
         $uuid = 'sfreact-'.uniqid();
-        $propsString = isset($options['props']) ? $options['props'] : '';
+        $propsString = isset($options['props']) ? $options['props'] : '{}';
         $str = '';
         $trace = $this->shouldTrace($options);
         if ($this->shouldRenderClientSide($options)) {


### PR DESCRIPTION
If `$options['props']` is not set the resulting html looked like this:

``` html
<div ... data-props ... /> 
```

and this line will fail: https://github.com/shakacode/react_on_rails/blob/master/node_package/src/clientStartup.js#L58

With the patch it will look like this:

``` html
<div ... data-props="{}" ... /> 
```

And we're fine :) 
