### PR TITLE
Only set phpExecJs's context if bundle changed

### DIFF
--- a/Renderer/ReactRenderer.php
+++ b/Renderer/ReactRenderer.php
@@ -11,6 +11,7 @@ class ReactRenderer
     protected $logger;
     protected $phpExecJs;
     protected $serverBundlePath;
+    protected $needToSetContext = true;
     protected $failLoud;
 
     public function __construct(LoggerInterface $logger, PhpExecJs $execJs, $serverBundlePath, $failLoud = false)
@@ -24,12 +25,16 @@ class ReactRenderer
     public function setServerBundlePath($serverBundlePath)
     {
         $this->serverBundlePath = $serverBundlePath;
+        $this->needToSetContext = true;
     }
 
     public function render($componentName, $propsString, $uuid, $trace)
     {
-        $serverBundle = $this->loadServerBundle();
-        $this->phpExecJs->createContext($this->consolePolyfill()."\n".$serverBundle);
+        if($this->needToSetContext){
+            $this->phpExecJs->createContext($this->consolePolyfill()."\n".$this->loadServerBundle());
+            $this->needToSetContext = false;
+        }
+
         $result = json_decode($this->phpExecJs->evalJs($this->wrap($componentName, $propsString, $uuid, $trace)), true);
         if ($result['hasErrors']) {
             $this->LogErrors($result['consoleReplayScript']);


### PR DESCRIPTION
If the bundle path did not change between to renders, we don't have to: 
- load in the bundle from disk again
- create the `consolePolyfill` code again
- create phpExecJs's context again 

right? 

I think this could increase performance quite a bit when rendering more then one component :) 
