### PR TITLE
Update composer.json to include version 4.0 for symfony libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     "require": {
         "php": ">=5.5.0",
         "nacmartin/phpexecjs": "^0.8",
-        "symfony/config": "^2.7.0|^3.0.6|^4.0.0",
-        "symfony/http-kernel": "^2.7.0|^3.0.6|^4.0.0",
-        "symfony/dependency-injection": "^2.7.0|^3.0.6|^4.0.0",
+        "symfony/config": "^2.7.0|^3.0.6|^4.0",
+        "symfony/http-kernel": "^2.7.0|^3.0.6|^4.0",
+        "symfony/dependency-injection": "^2.7.0|^3.0.6|^4.0",
         "limenius/react-renderer": "^0.14.0"
     },
     "require-dev": {
@@ -36,5 +36,6 @@
         "post-update-cmd": [
             "@default-scripts"
         ]
-    }
+    },
+    "minimum-stability": "beta"
 }

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,4 @@
             "@default-scripts"
         ]
     },
-    "minimum-stability": "beta"
 }

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     "require": {
         "php": ">=5.5.0",
         "nacmartin/phpexecjs": "^0.8",
-        "symfony/config": "^2.7.0|^3.0.6",
-        "symfony/http-kernel": "^2.7.0|^3.0.6",
-        "symfony/dependency-injection": "^2.7.0|^3.0.6",
+        "symfony/config": "^2.7.0|^3.0.6|^4.0.0",
+        "symfony/http-kernel": "^2.7.0|^3.0.6|^4.0.0",
+        "symfony/dependency-injection": "^2.7.0|^3.0.6|^4.0.0",
         "limenius/react-renderer": "^0.14.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,5 @@
         "post-update-cmd": [
             "@default-scripts"
         ]
-    },
+    }
 }


### PR DESCRIPTION
- Tested composer.json locally with minimum stability on beta, as it would otherwise only go up to 3.3.13

- Composer installed the packages, however I did not test it through the sandbox because the Liform is not up to date yet.

#SymfonyConHackday2017