### PR TITLE
Adding a static renderer

### DIFF
--- a/DependencyInjection/Compiler/CacheCompilerPass.php
+++ b/DependencyInjection/Compiler/CacheCompilerPass.php
@@ -20,5 +20,9 @@ class CacheCompilerPass implements CompilerPassInterface
             ->getDefinition('limenius_react.phpexecjs_react_renderer')
             ->addMethodCall('setCache', [$appCache, $key])
             ;
+
+        $container->getDefinition('limenius_react.static_react_renderer')
+            ->addMethodCall('setCache', [$appCache, $key])
+            ;
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,6 +8,7 @@
         <parameter key="limenius_react.external_react_renderer.class">Limenius\ReactRenderer\Renderer\ExternalServerReactRenderer</parameter>
         <parameter key="limenius_react.phpexecjs_react_renderer.class">Limenius\ReactRenderer\Renderer\PhpExecJsReactRenderer</parameter>
         <parameter key="limenius_react.context_provider.class">Limenius\ReactRenderer\Context\SymfonyContextProvider</parameter>
+        <parameter key="limenius_react.static_react_renderer.class">Limenius\ReactRenderer\Renderer\StaticReactRenderer</parameter>
     </parameters>
 
     <services>
@@ -26,5 +27,6 @@
             <argument type="service" id="limenius_react.context_provider" />
             <argument type="service" id="logger" />
         </service>
+        <service id="limenius_react.static_react_renderer" class="%limenius_react.static_react_renderer.class%" />
     </services>
 </container>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -11,6 +11,7 @@
     <services>
         <service id="limenius_react.render_extension" class="%limenius_react.render_extension.class%">
             <argument type="service" id="limenius_react.react_renderer" on-invalid="null"/>
+            <argument type="service" id="limenius_react.static_react_renderer" on-invalid="null" />
             <argument type="service" id="limenius_react.context_provider" />
             <argument>%limenius_react.default_rendering%</argument>
             <argument>%limenius_react.trace%</argument>


### PR DESCRIPTION
This addresses issue #19 by adding a StaticReactRenderer which wraps around an existing renderer to provide caching, and registers two new twig functions to call this