### PR TITLE
[Symfony 4.2] Update dependency injection configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace Limenius\ReactBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Class Configuration
@@ -15,8 +16,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('limenius_react');
+        if (Kernel::VERSION_ID >= 40200) {
+            $treeBuilder = new TreeBuilder('limenius_react');
+            $node = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $node = $treeBuilder->root('limenius_react');
+        }
+        
         $rootNode
             ->children()
                 ->enumNode('default_rendering')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,10 +18,10 @@ class Configuration implements ConfigurationInterface
     {
         if (Kernel::VERSION_ID >= 40200) {
             $treeBuilder = new TreeBuilder('limenius_react');
-            $node = $treeBuilder->getRootNode();
+            $rootNode = $treeBuilder->getRootNode();
         } else {
             $treeBuilder = new TreeBuilder();
-            $node = $treeBuilder->root('limenius_react');
+            $rootNode = $treeBuilder->root('limenius_react');
         }
         
         $rootNode


### PR DESCRIPTION
**A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.**

As your bundle is used in multiple symfony versions, I added check against symfony kernel version to load correct treebuilder initialization to remove deprication notice