### PR TITLE
[Symfony 4.3] Update dependency injection configuration 

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('limenius_react');
         if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
         } else {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,7 +16,12 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('limenius_react');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('limenius_react');
+        }
         $rootNode
             ->children()
                 ->enumNode('default_rendering')

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "limenius/react-bundle",
+    "name": "mkuhles/react-bundle",
     "description": "Client and Server-side react rendering in a Symfony Bundle",
     "type": "symfony-bundle",
     "keywords": ["react", "isomorphic"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mkuhles/react-bundle",
+    "name": "limenius/react-bundle",
     "description": "Client and Server-side react rendering in a Symfony Bundle",
     "type": "symfony-bundle",
     "keywords": ["react", "isomorphic"],


### PR DESCRIPTION
Deprecation Messages
> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
> 
> The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "limenius_react" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.

There is still a pull request in your repository concerning part of this problem [[Symfony 4.2] Update dependency injection configuration](https://github.com/Limenius/ReactBundle/pull/40). Since that one needs some more work a added this one.

thanks to the comment by @deguif in https://github.com/Limenius/ReactBundle/pull/40

